### PR TITLE
CompatHelper: bump compat for JuliaFormatter to 2, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ ShiftedProximalOperators = "d4fd37fa-580c-4e43-9b30-361c21aae263"
 proxTV_jll = "700117f8-5dbb-54dd-9908-6f3eb0e21f87"
 
 [compat]
-JuliaFormatter = "1"
+JuliaFormatter = "1, 2"
 LAPACK_jll = "3.12.0"
 LinearAlgebra = "1"
 OpenBLAS32_jll = "0.3.21"


### PR DESCRIPTION
This pull request changes the compat entry for the `JuliaFormatter` package from `1` to `1, 2`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.